### PR TITLE
Set password upon API user creation & Flask warning (global_limits)

### DIFF
--- a/apisrv/__init__.py
+++ b/apisrv/__init__.py
@@ -78,7 +78,7 @@ if 'debug' in config['apisrv'] and int(config['apisrv']['debug']) != 0:
 
 # Enable logging to file if configured
 if 'logfile' in config['apisrv']:
-    lfh = RotatingFileHandler(config['apisrv']['logfile'], maxBytes=(1048576*5), backupCount=3)
+    lfh = RotatingFileHandler(config['apisrv']['logfile'], maxBytes=(1048576 * 5), backupCount=3)
     lfh.setFormatter(lformat)
     logger.addHandler(lfh)
 
@@ -96,9 +96,9 @@ app.config.update(dict(
     DATABASE=os.path.join(app.root_path, config['apisrv']['database']),
     SQLALCHEMY_DATABASE_URI='sqlite:///' + os.path.join(app.root_path, config['apisrv']['database']),
     SQLALCHEMY_TRACK_MODIFICATIONS=False,
-    #SECRET_KEY='development key',
-    #USERNAME='dbuser',
-    #PASSWORD='dbpass'
+    # SECRET_KEY='development key',
+    # USERNAME='dbuser',
+    # PASSWORD='dbpass'
 ))
 
 # Auth module
@@ -111,8 +111,9 @@ db = SQLAlchemy(app)
 limiter = Limiter(
     app,
     key_func=get_remote_address,
-    global_limits=flask_limits
+    default_limits=flask_limits
 )
+
 
 def get_bolt_db():
     """Store nglib database handle under thread"""
@@ -121,12 +122,14 @@ def get_bolt_db():
         bdb = g._boltdb = nglib.get_bolt_db()
     return bdb
 
+
 def get_py2neo_db():
     """Store nglib database handle under thread"""
     pydb = getattr(g, '_py2neodb', None)
     if pydb is None:
         pydb = g._py2neodb = nglib.get_py2neo_db()
     return pydb
+
 
 @app.before_request
 def init_db():
@@ -138,6 +141,7 @@ def init_db():
     g.neo4j_db_bolt = nglib.bolt_ses
     nglib.py2neo_ses = get_py2neo_db()
     g.neo4j_db_py2neo = nglib.py2neo_ses
+
 
 @app.teardown_appcontext
 def close_db(error):
@@ -171,17 +175,17 @@ def upgrade_api(ngt, version):
         nt = nglib.ngtree.upgrade.upgrade_ngt_v2(ngt)
     return nt
 
+
 def version_chk(version, versions=['v1.1', 'v2']):
     'Make sure version in versions'
 
     if version not in versions:
         return jsonify(errors.json_error('API Version Error', 'Version ' \
-            + version + ' not supported on this endpoint'))
+                                         + version + ' not supported on this endpoint'))
+
 
 # Safe circular imports per Flask guide
 import apisrv.errors
 import apisrv.views
 import apisrv.user
 import apisrv.netdb
-
-

--- a/ctlsrv.py
+++ b/ctlsrv.py
@@ -45,6 +45,7 @@ parser = argparse.ArgumentParser(prog='ctlsrv.py',
 parser.add_argument('--run', help='Run the API Server', action="store_true")
 parser.add_argument("--adduser", metavar="user", help="Add API User to DB", type=str)
 parser.add_argument("--newpass", metavar="user", help="Update Password", type=str)
+parser.add_argument("--setpass", metavar="password", help="Set Password", type=str)
 parser.add_argument("--testuser", metavar="user", help="Test Authentication", type=str)
 parser.add_argument("--deluser", metavar="user", help="Delete API User", type=str)
 parser.add_argument("--initdb", help="Initialize the Database", action="store_true")
@@ -106,9 +107,12 @@ elif args.run:
 
 # Add user to DB
 elif args.adduser:
-
-    passwd = getpass.getpass('Password:')
-    verify = getpass.getpass('Verify Password:')
+    if not args.setpass:
+        passwd = getpass.getpass('Password:')
+        verify = getpass.getpass('Verify Password:')
+    else:
+        passwd = args.setpass
+        verify = args.setpass
 
     if passwd == verify:
         phash = apisrv.user.add_user(args.adduser, passwd)
@@ -132,6 +136,10 @@ elif args.newpass:
             print("Error: Could not Update Password")
     else:
         print("Error: Passwords do not match")
+
+# Update User Password
+elif args.setpass:
+    print("Error: Set password is only usable in combination with --adduser")
 
 # Delete a User
 elif args.deluser:

--- a/docs/API.md
+++ b/docs/API.md
@@ -12,14 +12,14 @@
   * Initialize the SQL Lite database: ```./ctlsrv.py --initdb```
   * Add an API User: ```./ctlsrv --adduser testuser```
   * Run the Server: ```./ctlsrv.py --run```
-  * Test a Query: ```curl -u testuser:testpass http://localhost:4096/netgrph/api/v1.1/devs```
+  * Test a Query: ```curl -u testuser:testpass http://localhost:4096/netgrph/api/v2/devs```
 
 # Examples
 
 ### Switch path
 
 ```
-$ curl -u testuser:testpass 'http://localhost:4096/netgrph/api/v1.0/spath?src=mdcmdf&dst=core1'
+$ curl -u testuser:testpass 'http://localhost:4096/netgrph/api/v2/spath?src=mdcmdf&dst=core1'
 {
   "Distance": 1,
   "Links": 1,
@@ -58,7 +58,7 @@ $ curl -u testuser:testpass 'http://localhost:4096/netgrph/api/v1.0/spath?src=md
 ### Networks on a filter (guest VRF with guest access role)
 
 ```
-curl -u testuser:testpass 'http://localhost:4096/netgrph/api/v1.1/nets?filter=guest:nac-guest'
+curl -u testuser:testpass 'http://localhost:4096/netgrph/api/v2/nets?filter=guest:nac-guest'
 {
   "Count": 23,
   "Filter": "guest:nac-guest",


### PR DESCRIPTION
Hi there, 
Today I tried to dockerize netgrph when I realized its not possible to configure a API service user account in a simple way. Mainly thats because of the user password can't be set via a `ctlsrv.py`. In Docker PID 1 needs to run all the time or the container will stop running. If I choose to run the netgrph API as PID 1, I didn't see another way to automatically configure the DB service account before I run `./ctlsrv.py --run`. That's the reason why I introduced the `--setpass` which allows it to set a password directly via parameter in combination with `--adduser`. Perhaps its not the nicest solution but for the moment it works.  I guess thats the point where it would be nice to get some feedback from you guys in order to find the best fitting solution for this requirement. What do you think about this newly introduced parameter? Do you see another solution for the described problem?
As soon as the dockerization of netgrph works, I will make the Dockerfile and Docker Compose file public accessible.

In the same way I also tried to fix a Flask warning about the `global_limits` variable:
```bash
netgrph_1  | /usr/local/lib/python3.5/dist-packages/flask_limiter/extension.py:559: UserWarning: global_limits was a badly name configuration since it is actually a default limit and not a  globally shared limit. Use default_limits if you want to provide a default or use application_limits  if you intend to really have a global shared limit
```
I just renamed `global_limits` to `default_limits` in `netgrph/apisrv/__init__.py` on line `114`. Do you think that makes sense? The warning doesn't show up anymore.

Thanks!

Regards,
Philip